### PR TITLE
First pass linux support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3860,6 +3860,9 @@ class UnityUtils {
         switch (os.platform()) {
             default:
                 throw new Error('Unsupported platform.');
+            case 'linux':
+                const homeDir = os.homedir();
+                return `${homeDir}/Unity/Hub/Editor`;
             case 'darwin':
                 return "/Applications/Unity/Hub/Editor";
             case 'win32':
@@ -3878,6 +3881,8 @@ class UnityUtils {
         switch (os.platform()) {
             default:
                 throw new Error('Unsupported platform.');
+            case 'linux':
+                return `${installDirectory}/${unityVersion}/Editor/Unity`;
             case 'darwin':
                 return `${installDirectory}/${unityVersion}/Unity.app/Contents/MacOS/Unity`;
             case 'win32':

--- a/dist/index.js
+++ b/dist/index.js
@@ -3861,8 +3861,10 @@ class UnityUtils {
             default:
                 throw new Error('Unsupported platform.');
             case 'linux':
-                const homeDir = os.homedir();
-                return `${homeDir}/Unity/Hub/Editor`;
+                {
+                    const homeDir = os.homedir();
+                    return `${homeDir}/Unity/Hub/Editor`;
+                }
             case 'darwin':
                 return "/Applications/Unity/Hub/Editor";
             case 'win32':

--- a/src/UnityUtils.ts
+++ b/src/UnityUtils.ts
@@ -45,8 +45,10 @@ export default class UnityUtils
         default:
             throw new Error('Unsupported platform.')
         case 'linux':
-            const homeDir = os.homedir();
-            return `${homeDir}/Unity/Hub/Editor`;
+            {
+                const homeDir = os.homedir();
+                return `${homeDir}/Unity/Hub/Editor`;
+            }
         case 'darwin':
             return "/Applications/Unity/Hub/Editor"
         case 'win32':

--- a/src/UnityUtils.ts
+++ b/src/UnityUtils.ts
@@ -44,6 +44,9 @@ export default class UnityUtils
         switch (os.platform()) {
         default:
             throw new Error('Unsupported platform.')
+        case 'linux':
+            const homeDir = os.homedir();
+            return `${homeDir}/Unity/Hub/Editor`;
         case 'darwin':
             return "/Applications/Unity/Hub/Editor"
         case 'win32':
@@ -64,6 +67,8 @@ export default class UnityUtils
         switch (os.platform()) {
         default:
             throw new Error('Unsupported platform.')
+        case 'linux':
+            return `${installDirectory}/${unityVersion}/Editor/Unity`
         case 'darwin':
             return `${installDirectory}/${unityVersion}/Unity.app/Contents/MacOS/Unity`
         case 'win32':


### PR DESCRIPTION
Adding support for building on linux. According to a quick google all versions of linux unityhub will install unity in the user's home in this way by default.

Tested on Ubuntu 24.04.3 LTS with Unity Hub 3.15.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Linux環境でのUnityハブディレクトリ検出とUnity実行ファイルパスの解決に対応しました。これによりLinux上での自動検出が可能になります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->